### PR TITLE
add whitespace at bottom of post body

### DIFF
--- a/components/post/Body.tsx
+++ b/components/post/Body.tsx
@@ -41,7 +41,7 @@ interface Props {
 
 export default function PostBody(props: Props) {
   return (
-    <div className="prose prose-xl prose-neutral mx-auto max-w-3xl">
+    <div className="prose prose-xl prose-neutral mx-auto max-w-3xl mb-8">
       <PortableText
         value={props.content}
         // @ts-expect-error PullQuote typing is difficult


### PR DESCRIPTION
Styling before:
![image](https://github.com/starschema/dataviz-blog/assets/16979238/3a1f3dc8-2d12-4e80-9687-f296fd41a379)

Add bottom margin to the Body component to match margin styling of other post components and avoid the text and the separator element being too close to each other.